### PR TITLE
Update GPAW install directions

### DIFF
--- a/gpaw/install.md
+++ b/gpaw/install.md
@@ -1,5 +1,12 @@
 # GPAW install and test directions
 
+##Prerequisite
+
+This version of GPAW depends on libxc ver. 6.2.2. First install libxc
+and then edit the `siteconfig.py` to point to location of the install.
+
+##Install
+
 Installing GPAW requires a `siteconfig.py` file tailored to Perlmutter.
 This file must be present in the same directory where `setup.py` is run.
 The directions below will use the `siteconfig.py` file stored in this
@@ -10,8 +17,6 @@ To install run the following commands:
 
 ```
 module load python cray-fftw
-module use /global/common/software/nersc/user/tmp_modulefile
-module load libxc/6.2.2
 conda create --name gpaw pip numpy scipy matplotlib
 source activate gpaw
 pip install ase

--- a/gpaw/siteconfig.py
+++ b/gpaw/siteconfig.py
@@ -71,9 +71,9 @@ if 0:
 #        libraries.remove('xc')
 
 # - dynamic linking (requires rpath or setting LD_LIBRARY_PATH at runtime):
-# Uses a temporary install of libxc
 if 1:
-    xc = '/global/common/software/nersc/user/libxc/6.2.2'
+    # Edit this line to point to the location of your libxc install
+    xc = '/your/path/to/libxc/6.2.2'
     include_dirs += [xc + 'include']
     library_dirs += [xc + 'lib']
     # You can use rpath to avoid changing LD_LIBRARY_PATH:


### PR DESCRIPTION
Since libxc offered as an official module update script to use new method to locate the installation.