### PR TITLE
Add scripts to build and install Relion

### DIFF
--- a/relion/build_relion_v4.sh
+++ b/relion/build_relion_v4.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+module load cray-fftw
+
+
+
+git clone -b 4.0.1 https://github.com/3dem/relion.git
+
+cd relion
+
+mkdir build; cd build
+mkdir install
+
+cmake --fresh .. \
+  -D CMAKE_INSTALL_PREFIX=$(realpath ./install) \
+  -D GUI=OFF \
+  -D CUDA_SDK_ROOT_DIR="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2" \
+  -D CUDA_cublas_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcublas.so" \
+  -D CUDA_cufft_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcufft.so" \
+  -D CUDA_curand_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcurand.so" \
+  -D CUDA_cusolver_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcusolver.so" \
+  -D CUDA_cusparse_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcusparse.so" 
+
+cmake --build . -j8
+
+
+cmake --install .

--- a/relion/build_relion_v5.sh
+++ b/relion/build_relion_v5.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+module load cray-fftw
+
+SOURCE_DIR="relion_ver5"
+
+git clone -b ver5.0 https://github.com/3dem/relion.git ${SOURCE_DIR}
+
+
+cd ${SOURCE_DIR}
+
+mkdir build; cd build
+mkdir install
+
+cmake --fresh .. \
+  -D CMAKE_INSTALL_PREFIX=$(realpath ./install) \
+  -D GUI=OFF \
+  -D CUDA_SDK_ROOT_DIR="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2" \
+  -D CUDA_cublas_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcublas.so" \
+  -D CUDA_cufft_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcufft.so" \
+  -D CUDA_curand_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcurand.so" \
+  -D CUDA_cusolver_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcusolver.so" \
+  -D CUDA_cusparse_LIBRARY="/opt/nvidia/hpc_sdk/Linux_x86_64/23.9/math_libs/12.2/lib64/libcusparse.so" 
+
+cmake --build . -j8
+
+
+cmake --install .


### PR DESCRIPTION
Relion's CMake build could not find the CUDA math libraries. Specifying them allowed the build to succeed.

Waiting for user to test (RE: INC0215354)